### PR TITLE
fixed readme typo from grunt to gulp

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,13 @@ To run the site you will need npm installed, this will get various modules for g
 
 ```
 npm install
-grunt
 ```
 
+To run the project, type:
+
+```
+gulp
+```
 
 A few notes:
 


### PR DESCRIPTION
we are using gulp not grunt. Unless you have secret files, I can't see 🎱 
